### PR TITLE
fixed path bug in plotRTT() function input

### DIFF
--- a/PyRate.py
+++ b/PyRate.py
@@ -2602,6 +2602,7 @@ if path_dir_log_files != "":
 		# plot each file separately
 		print root_plot 
 		if file_stem == "":
+			path_dir_log_files = os.path.abspath(path_dir_log_files)
 			direct="%s/*marginal_rates.log" % path_dir_log_files
 			files=glob.glob(direct)
 			files=sort(files)		


### PR DESCRIPTION
when running the plotRTT() function pyrate usually returns the error that it can't find the input file, as it is searching for it in the very root directory '/'. This line of code fixes the issue, so that pyrate takes the whole path of the input file and parses that into the function.