### PR TITLE
Fix MBD outfile name .txt problem

### DIFF
--- a/PyRateMBD.py
+++ b/PyRateMBD.py
@@ -315,7 +315,7 @@ else:
 	GarrayA[fixed_focal_clade,:,:] += np.random.normal(0,0.001,np.shape(GarrayA[fixed_focal_clade,:,:]))
 	print dataset,args.j,model_name,out_tag
 	dataset_name = dataset.replace(".txt", "")
-	out_file_name="%s_%s_%s_%sMBD.log" % (dataset,args.j,model_name,out_tag)
+	out_file_name="%s_%s_%s_%sMBD.log" % (dataset_name,args.j,model_name,out_tag)
 	logfile = open(out_file_name , "wb") 
 	wlog=csv.writer(logfile, delimiter='\t')
 

--- a/PyRateMBD.py
+++ b/PyRateMBD.py
@@ -314,6 +314,7 @@ if plot_RTT is True:
 else:
 	GarrayA[fixed_focal_clade,:,:] += np.random.normal(0,0.001,np.shape(GarrayA[fixed_focal_clade,:,:]))
 	print dataset,args.j,model_name,out_tag
+	dataset_name = dataset.replace(".txt", "")
 	out_file_name="%s_%s_%s_%sMBD.log" % (dataset,args.j,model_name,out_tag)
 	logfile = open(out_file_name , "wb") 
 	wlog=csv.writer(logfile, delimiter='\t')


### PR DESCRIPTION
When `PyRateMBD.py` runs, the output filename is a concatenation of `dataset_name`, `args.j`, `model_name`, and `out_tag`. Unfortunately, `dataset_name` usually ends in `.txt` so we wind up with a logfile named, for example, `[analysis details]_se_est.txt_ 0_lin_MBD.log`. 

I have introduced a change that simply removes `.txt` from the dataset filename and uses that new variable for `out_file_name` instead.