### PR TITLE
Dissolve for loop that concatanate string to Python str.join API as s…

### DIFF
--- a/PyRate.py
+++ b/PyRate.py
@@ -890,7 +890,7 @@ def comb_mcmc_files(infile, files,burnin,tag,resample,col_tag,file_type=""):
                 head_temp= np.array(head_temp)
                 head_t= ["%s\t" % (i) for i in head_temp[sp_ind]]
                 tbl_header="it\t"
-                for i in head_t: tbl_header+=i
+                tbl_header+=''.join([ht for ht in head_t])
                 tbl_header+="\n"
                 print("found", len(head_t), "columns")
                 comb = t_file[:,sp_ind]
@@ -1062,7 +1062,7 @@ def comb_log_files(path_to_files,burnin=0,tag="",resample=0,col_tag=[]):
                 head_temp= np.array(head_temp)
                 head_t= ["%s\t" % (i) for i in head_temp[sp_ind]]
                 tbl_header="it\t"
-                for i in head_t: tbl_header+=i
+                tbl_header += ''.join([ht for ht in head_t])
                 tbl_header+="\n"
                 print("found", len(head_t), "columns")
                 comb = t_file[:,sp_ind]


### PR DESCRIPTION
`tr.join` is an efficient way to concatanate strings than using a for loop