### PR TITLE
Avoids counting a species ending with "q" as a q_rate column

### DIFF
--- a/pyrate_lib/rtt_plot_bds.py
+++ b/pyrate_lib/rtt_plot_bds.py
@@ -141,7 +141,7 @@ def RTTplot_Q(f,q_shift_file,burnin=0,max_age=0):
         print("removed heated chains:",np.shape(t))
     
     head= list(head)
-    q_ind = [head.index(s) for s in head if "q_" in s]
+    q_ind = [head.index(s) for s in head if "q_" in s and s.split("q_")[1] not in ['TS', 'TE']]
     root_ind  = head.index("root_age")
     death_ind = head.index("death_age")
     min_root_age = min(t[:,root_ind])


### PR DESCRIPTION
Although this is quite anecdotal, the former condition to target q_rate columns in the header of the mcmc.log file couldn't differentiate true q_rate columns (e.g. "q_1", "q_2",...) and cases like "<species_name>_TS" or "<species_name>_TE", where <species_name> ends with the letter "q". This happened to me with the "Kiruwamaq" genus (South American Palaeogene marsupial). Hope it might help some way...