### PR TITLE
pin numpy to pre-2.0 version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.16.4
+numpy>=1.16.4,<2.0
 scipy>=1.4.1
 dendropy>=4.4.0
 pandas~=1.4.3


### PR DESCRIPTION
I recently installed Pyrate and found that the `requirements.txt`  file needs to updated to prevent pip from installing the Numpy 2.0, which does not seem to be compatible with PyRate.

This PR will force pip to choose a version of Numpy >=1.16.4 and < 2.0.

Best,
Dave