### PR TITLE
Update lib_utilities.py write_ts_te_table function

### DIFF
--- a/pyrate_lib/lib_utilities.py
+++ b/pyrate_lib/lib_utilities.py
@@ -157,9 +157,9 @@ def write_ts_te_table(path_dir, tag="",clade=0,burnin=0.1,plot_ltt=True, n_sampl
     
                 if platform.system() == "Windows" or platform.system() == "Microsoft":
                     wd_forward = os.path.abspath(wd).replace('\\', '/')
-                    r_script= "\ntry({\npdf(file='%s/%s_LTT.pdf',width=0.6*20, height=0.6*10)\n" % (wd_forward,name_file)
+                    r_script= "\n\npdf(file='%s/%s_LTT.pdf',width=0.6*20, height=0.6*10)\n" % (wd_forward,name_file)
                 else: 
-                    r_script= "\ntry({\npdf(file='%s/%s_LTT.pdf',width=0.6*20, height=0.6*10)\n" % (wd,name_file)
+                    r_script= "\n\npdf(file='%s/%s_LTT.pdf',width=0.6*20, height=0.6*10)\n" % (wd,name_file)
     
                 R_ts = print_R_vec("ts",ts)
                 R_te = print_R_vec("te",te)
@@ -183,7 +183,6 @@ def write_ts_te_table(path_dir, tag="",clade=0,burnin=0.1,plot_ltt=True, n_sampl
 
                 # Explicitly close the PDF device
                 dev.off()
-                })
                 """
                 
                 r_file.writelines(r_script)


### PR DESCRIPTION
Two key fixes to the LTT plot creation. Earlier, when I used -ginput to create the ltt plots, I edited the x axis a little then re-ran the ltt.r script and tried to re-open the PDF. However, the PDF could not be re-opened. It would say that the file was open elsewhere

Fixed it by:
1. `try({})`: Error-handling wrapper so if errors occur (like file permission issues or device problems), it catches them instead of crashing

3. `dev.off()`: explicitly closes the PDF graphics device in R so that the file doesn't get "locked" or incomplete (this is why I was unable to open it. It wasn't properly finalized/closed)

Also added missing underscores for the Terminal output message