### PR TITLE
fix ValueError in combine_pkl function

### DIFF
--- a/pyrate_lib/bdnn_lib.py
+++ b/pyrate_lib/bdnn_lib.py
@@ -237,8 +237,8 @@ def combine_pkl(path_to_files, tag, burnin, resample):
             direct_mcmc = "%s/*%s*_mcmc.log" % (infile, tag)
             files_mcmc = glob.glob(direct_mcmc)
             name_combined_mcmc = "%s/combined_%s%s_mcmc.log" % (infile, num_replicates, tag)
-            files_mcmc.remove(name_combined_mcmc)
-            files_mcmc = np.sort(files_mcmc)
+            # files_mcmc.remove(name_combined_mcmc)
+            # files_mcmc = np.sort(files_mcmc)
 
             with open(files_mcmc[0], 'r') as f:
                 header_mcmc_log = next(f).strip()


### PR DESCRIPTION
When running -combBDNN, if these two lines (240-241) are active (I commented them out), it leads to this error:

Traceback (most recent call last):
  File "path_to_PyRate.py", line 6477, in <module>
    combine_pkl(args.combBDNN, tag, burnin, args.resample)
  File "path_to_bdnn_lib.py", line 240, in combine_pkl
    files_mcmc.remove(name_combined_mcmc)
ValueError: list.remove(x): x not in list